### PR TITLE
Let users choose which HTML tags they don't want to render

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -2,7 +2,7 @@ td {
   vertical-align: top;
 }
 
-#selSite, #txtAddSite {
+#selSite, #txtAddSite, #selTag, #txtAddTag {
   min-width: 250px;
 }
 

--- a/js/background.js
+++ b/js/background.js
@@ -57,7 +57,8 @@ chrome.webRequest.onHeadersReceived.addListener(function(details) {
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   if (request.method == 'shouldTeXify') {
     sendResponse({answer: should_texify(request.host),
-                  delimiters: get_delimiters()});
+                  delimiters: get_delimiters(),
+                  skip_tags: get_skip_tags()});
   } else {
     sendResponse({});
   }
@@ -96,4 +97,8 @@ function get_delimiters() {
   delimiters.display_bracket = get_option('display_bracket');
   delimiters.display_custom = get_option('display_custom')
   return delimiters;
+}
+
+function get_skip_tags(){
+  return get_option('skip_tags')
 }

--- a/js/options.js
+++ b/js/options.js
@@ -7,7 +7,8 @@ var default_options = {
   inline_custom: false,
   display_dollar: true,
   display_bracket: true,
-  display_custom: false
+  display_custom: false,
+  skip_tags: ['script','noscript','style','textarea','pre','code']
 };
 
 function get_option(option_name) {
@@ -34,4 +35,12 @@ function set_option(option_name, value) {
 
 function option_allowed(option_name) {
   return (option_name in default_options);
+}
+
+function get_default_option(option_name) {
+  if (option_allowed(option_name)) {
+    return default_options[option_name];
+  } else {
+    throw "Option " + option_name + " not supported";
+  }
 }

--- a/js/optionsPage.js
+++ b/js/optionsPage.js
@@ -34,6 +34,13 @@ function save_options() {
     set_option('display_custom', false);
   }
 
+  // tex2jax Skip Tags
+  var skip_tags = [];
+  $('#selTag>option').each(function() {
+    skip_tags.push($(this).val());
+  });
+  set_option('skip_tags', skip_tags);
+
   // Save the site list
   var sites = [];
   $('#selSite>option').each(function() {
@@ -76,6 +83,15 @@ function restore_options() {
     $('#customDisplayClose').val(display_custom[1]);
   }
 
+  // tex2jax Skip Tags
+  var skip_tags = get_option('skip_tags');
+  $.each(skip_tags, function(index, tag) {
+    $('#selTag').append($('<option>', {
+      value: tag,
+      text : tag
+    }));
+  });
+
   // Load the site list
   var sites = get_option('sites');
   $.each(sites, function(index, site) {
@@ -111,6 +127,37 @@ function clear_sites() {
   $('#selSite>option').remove();
 }
 
+function add_tag() {
+  var tag = $('#txtAddTag').val().trim();
+  $('#txtAddTag').val('');
+
+  if (tag !== '') {
+    $('#selTag').append($('<option>', {
+      value: tag,
+      text : tag,
+    }));
+  }
+}
+
+function remove_tag() {
+  $('#selTag>option:selected').remove();
+}
+
+function clear_tags() {
+  $('#selTag>option').remove();
+}
+
+function restore_default_tags() {
+  var default_tags = get_default_option('skip_tags');
+  clear_tags()
+  $.each(default_tags, function(index, tag) {
+    $('#selTag').append($('<option>', {
+      value: tag,
+      text : tag
+    }));
+  });
+}
+
 function displayMessage(message) {
   $('#status').text(message).addClass('visible');
   setTimeout(function() {
@@ -122,7 +169,19 @@ $(function() {
   $('#btnAddSite').click(add_site);
   $('#btnRemoveSite').click(remove_site);
   $('#btnClearSite').click(clear_sites);
+
+  $('#btnAddTag').click(add_tag);
+  $('#btnRemoveTag').click(remove_tag);
+  $('#btnClearTag').click(clear_tags);
+  $('#btnDefaultTags').click(restore_default_tags);
+
   $('#save').click(save_options);
+
+  $("#txtAddTag").keyup(function(event){
+    if(event.keyCode == 13) {
+        $("#btnAddTag").click();
+    }
+  });
 
   $("#txtAddSite").keyup(function(event){
     if(event.keyCode == 13) {

--- a/js/pageScript.js
+++ b/js/pageScript.js
@@ -5,7 +5,8 @@ function config() {
     messageStyle: 'none',
     tex2jax: {
       inlineMath: JSON.parse(scriptNode.getAttribute('inlineMath')),
-      displayMath: JSON.parse(scriptNode.getAttribute('displayMath'))
+      displayMath: JSON.parse(scriptNode.getAttribute('displayMath')),
+      skipTags: JSON.parse(scriptNode.getAttribute('skipTags'))
     }
   });
 }

--- a/js/texify.js
+++ b/js/texify.js
@@ -34,6 +34,7 @@ chrome.runtime.sendMessage({method: 'shouldTeXify', host: location.host},
       pageScript.src = chrome.extension.getURL('js/pageScript.js');
       pageScript.setAttribute('inlineMath', JSON.stringify(inline_delimiters));
       pageScript.setAttribute('displayMath', JSON.stringify(display_delimiters));
+      pageScript.setAttribute('skipTags', JSON.stringify(response.skip_tags));
 
 
       document.body.appendChild(mathjax);

--- a/options.html
+++ b/options.html
@@ -25,6 +25,27 @@
     </div>
   </div>
 
+  <h2>HTML Tag Filter</h2>
+  <p class="optionInfo">
+    Add HTML tags to the list below (e.g. script, code). The contents of these tags will not be typeset.
+  </p>
+  <table>
+    <tbody>
+      <tr>
+        <td><input type="text" id="txtAddTag"></td>
+        <td><button id="btnAddTag">Add</button></td>
+      </tr>
+      <tr>
+        <td><select size="8" id="selTag"></select></td>
+        <td>
+          <button id="btnRemoveTag">Remove</button><br>
+          <button id="btnClearTag">Clear</button>
+          <button id="btnDefaultTags">Restore Defaults</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
   <h2>Site Filter</h2>
   <p class="optionInfo">
     Add domains and subdomains to the list below (e.g. facebook.com, code.google.com).


### PR DESCRIPTION
Users can list which tags they want MathJax to ignore; these tags are given
to tex2jax's "skipTags" option. If the user does not change it, this list is
tex2jax's default, which is script, noscript, style, textarea, pre, and code.

The new setting on the options page is basically a copy of the Sites option.
There is also a button to restore the default tag list.

Partially addresses #24. (Thanks @Hoten for your helpful information.) I 
couldn't think of a good way to let users choose tags on a per-site basis.
Sorry about that.

I've never worked with js or web dev at all, so I'm sure I've made style errors,
or done things in a weird or inefficient way. Sorry about that, too.