### PR TITLE
added ignoreClass and processClass tex2jax options

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -54,3 +54,8 @@ td {
   width: 2em;
   margin-left: .5em;
 }
+
+.classBox {
+  width: 20em;
+  margin-left: .5em;
+}

--- a/js/background.js
+++ b/js/background.js
@@ -58,7 +58,9 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   if (request.method == 'shouldTeXify') {
     sendResponse({answer: should_texify(request.host),
                   delimiters: get_delimiters(),
-                  skip_tags: get_skip_tags()});
+                  skip_tags: get_skip_tags(),
+                  ignore_class: get_ignore_class(),
+                  process_class: get_process_class()});
   } else {
     sendResponse({});
   }
@@ -95,10 +97,18 @@ function get_delimiters() {
   delimiters.inline_custom = get_option('inline_custom')
   delimiters.display_dollar = get_option('display_dollar');
   delimiters.display_bracket = get_option('display_bracket');
-  delimiters.display_custom = get_option('display_custom')
+  delimiters.display_custom = get_option('display_custom');
   return delimiters;
 }
 
 function get_skip_tags(){
-  return get_option('skip_tags')
+  return get_option('skip_tags');
+}
+
+function get_ignore_class(){
+  return get_option('ignore_class');
+}
+
+function get_process_class(){
+  return get_option('process_class');
 }

--- a/js/options.js
+++ b/js/options.js
@@ -8,6 +8,8 @@ var default_options = {
   display_dollar: true,
   display_bracket: true,
   display_custom: false,
+  ignore_class: false,
+  process_class: false,
   skip_tags: ['script','noscript','style','textarea','pre','code']
 };
 

--- a/js/optionsPage.js
+++ b/js/optionsPage.js
@@ -51,6 +51,27 @@ function save_options() {
   // White List Mode
   set_option('white_list_mode', $('#chkWhiteListMode').is(':checked'));
 
+  // tex2jax Ignore Class
+  var ignore_class = $('#ignoreClass').val().trim();
+  if (!ignore_class) {
+    ignore_class = "tex2jax_ignore";
+  }
+  if ($('#chkIgnoreClass').is(':checked') && ignore_class) {
+    set_option('ignore_class', ignore_class);
+  } else {
+    set_option('ignore_class', false);
+  }
+  // tex2jax Process Class
+  var process_class = $('#processClass').val().trim();
+  if (!process_class) {
+    process_class = "tex2jax_process";
+  }
+  if ($('#chkProcessClass').is(':checked') && process_class) {
+    set_option('process_class', process_class);
+  } else {
+    set_option('process_class', false);
+  }
+
   displayMessage('Options saved.');
 }
 
@@ -100,6 +121,20 @@ function restore_options() {
         text : site
     }));
   });
+  
+  // tex2jax Ignore Class
+  var ignore_class = get_option('ignore_class');
+  if(ignore_class) {
+    $('#chkIgnoreClass').prop('checked', true);
+    $('#ignoreClass').val(ignore_class);
+  }
+
+  // tex2jax Process Class
+  var process_class = get_option('process_class');
+  if(process_class) {
+    $('#chkProcessClass').prop('checked', true);
+    $('#processClass').val(process_class);
+  }
 
   // White List Mode
   if (get_option('white_list_mode')) {
@@ -149,7 +184,7 @@ function clear_tags() {
 
 function restore_default_tags() {
   var default_tags = get_default_option('skip_tags');
-  clear_tags()
+  clear_tags();
   $.each(default_tags, function(index, tag) {
     $('#selTag').append($('<option>', {
       value: tag,

--- a/js/pageScript.js
+++ b/js/pageScript.js
@@ -6,7 +6,9 @@ function config() {
     tex2jax: {
       inlineMath: JSON.parse(scriptNode.getAttribute('inlineMath')),
       displayMath: JSON.parse(scriptNode.getAttribute('displayMath')),
-      skipTags: JSON.parse(scriptNode.getAttribute('skipTags'))
+      skipTags: JSON.parse(scriptNode.getAttribute('skipTags')),
+      ignoreClass: JSON.parse(scriptNode.getAttribute('ignoreClass')),
+      processClass: JSON.parse(scriptNode.getAttribute('processClass'))
     }
   });
 }

--- a/js/texify.js
+++ b/js/texify.js
@@ -35,7 +35,8 @@ chrome.runtime.sendMessage({method: 'shouldTeXify', host: location.host},
       pageScript.setAttribute('inlineMath', JSON.stringify(inline_delimiters));
       pageScript.setAttribute('displayMath', JSON.stringify(display_delimiters));
       pageScript.setAttribute('skipTags', JSON.stringify(response.skip_tags));
-
+      pageScript.setAttribute('ignoreClass', JSON.stringify(response.ignore_class));
+      pageScript.setAttribute('processClass', JSON.stringify(response.process_class));
 
       document.body.appendChild(mathjax);
       document.body.appendChild(pageScript);

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "short_name": "TeX Things",
   "author": "emichael",
   "description": "An extension which lets you enable LaTeX on any website",
-  "version": "1.1.4",
+  "version": "1.1.5",
 
   "icons": {
     "128": "img/icon128.png",

--- a/options.html
+++ b/options.html
@@ -81,7 +81,7 @@
 
   <h2>Processed Classes Regex</h2>
   <p class="optionInfo">
-    Add a class name below to mark elements whose contents <i>should</i> be processed, even if they would have been ignored by "Ignore Class."<br>
+    Add a class name below to mark elements whose contents <i>should</i> be processed, even if they would have been ignored by "Ignored Classes Regex."<br>
     Note that this is a regular expression, and so you need to be sure to quote any regexp special characters. The pattern is inserted into one that requires your pattern to match a complete word, so setting the pattern to "class2" will cause it to match an element with class="class1 class2 class3" but not class="myclass2". Note that you can assign several classes by separating them by the vertical line character (|). For instance, with the pattern set to  "class1|class2" any element assigned a class of either class1 or class2 will be processed.
   </p>
   <p><input type="checkbox" id="chkProcessClass">Process Class:<input type="text" id="processClass" class="classBox"></p>

--- a/options.html
+++ b/options.html
@@ -72,6 +72,20 @@
     Otherwise, only domains in the list will <em>not</em> be typeset.
   </p>
 
+  <h2>Ignore Class</h2>
+  <p class="optionInfo">
+    Add a class name below to mark elements whose contents should not be processed. <br>
+    Note that this is a regular expression, and so you need to be sure to quote any regexp special characters. The pattern is inserted into one that requires your pattern to match a complete word, so setting the pattern to "class2" will cause it to match an element with class="class1 class2 class3" but not class="myclass2". Note that you can assign several classes by separating them by the vertical line character (|). For instance, with the pattern set to  "class1|class2" any element assigned a class of either class1 or class2 will be skipped.
+  </p>
+  <p><input type="checkbox" id="chkIgnoreClass">Ignore Class:<input type="text" id="ignoreClass" class="classBox"></p>
+
+  <h2>Process Class</h2>
+  <p class="optionInfo">
+    Add a class name below to mark elements whose contents <i>should</i> be processed. This is used to restart processing within tags that have been marked as ignored via the ignoreClass or to cause a tag that appears in the skipTags list to be processed rather than skipped.<br>
+    Note that this is a regular expression, and so you need to be sure to quote any regexp special characters. The pattern is inserted into one that requires your pattern to match a complete word, so setting the pattern to "class2" will cause it to match an element with class="class1 class2 class3" but not class="myclass2". Note that you can assign several classes by separating them by the vertical line character (|). For instance, with the pattern set to  "class1|class2" any element assigned a class of either class1 or class2 will be processed.
+  </p>
+  <p><input type="checkbox" id="chkProcessClass">Process Class:<input type="text" id="processClass" class="classBox"></p>
+
   <button id="save">Save</button>
 
   <script src="js/jquery.min.js"></script>

--- a/options.html
+++ b/options.html
@@ -72,16 +72,16 @@
     Otherwise, only domains in the list will <em>not</em> be typeset.
   </p>
 
-  <h2>Ignore Class</h2>
+  <h2>Ignored Classes Regex</h2>
   <p class="optionInfo">
     Add a class name below to mark elements whose contents should not be processed. <br>
     Note that this is a regular expression, and so you need to be sure to quote any regexp special characters. The pattern is inserted into one that requires your pattern to match a complete word, so setting the pattern to "class2" will cause it to match an element with class="class1 class2 class3" but not class="myclass2". Note that you can assign several classes by separating them by the vertical line character (|). For instance, with the pattern set to  "class1|class2" any element assigned a class of either class1 or class2 will be skipped.
   </p>
   <p><input type="checkbox" id="chkIgnoreClass">Ignore Class:<input type="text" id="ignoreClass" class="classBox"></p>
 
-  <h2>Process Class</h2>
+  <h2>Processed Classes Regex</h2>
   <p class="optionInfo">
-    Add a class name below to mark elements whose contents <i>should</i> be processed. This is used to restart processing within tags that have been marked as ignored via the ignoreClass or to cause a tag that appears in the skipTags list to be processed rather than skipped.<br>
+    Add a class name below to mark elements whose contents <i>should</i> be processed, even if they would have been ignored by "Ignore Class."<br>
     Note that this is a regular expression, and so you need to be sure to quote any regexp special characters. The pattern is inserted into one that requires your pattern to match a complete word, so setting the pattern to "class2" will cause it to match an element with class="class1 class2 class3" but not class="myclass2". Note that you can assign several classes by separating them by the vertical line character (|). For instance, with the pattern set to  "class1|class2" any element assigned a class of either class1 or class2 will be processed.
   </p>
   <p><input type="checkbox" id="chkProcessClass">Process Class:<input type="text" id="processClass" class="classBox"></p>


### PR DESCRIPTION
Hello, I was having a hard time using the extension with Confluence wiki editors, so I added the tex2jax option for ignoring or forcing processing of classes, per https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax